### PR TITLE
[issues/58] Fix manifest package from omrecorder to com.omrecorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.iml
 .gradle
-/.idea/workspace.xml
+/.idea
 /.idea/libraries
 .DS_Store
 /build

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 Om Recorder
 ============
 
+### Grab maintenance
+
+The owner in not maintaining the library anymore and to fix any issue
+Pax App Core has decided to host the original repo under local artifactory.
+
 ![Logo](website/static/om.png)
 
 A Simple Pcm / Wav audio recorder with nice api. 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url 'https://dl.bintray.com/kailash09dabhi/maven' }
     }
 }
 

--- a/om-recorder/build.gradle
+++ b/om-recorder/build.gradle
@@ -18,11 +18,6 @@ android {
   }
 }
 ext {
-  // Where you will see your artifact in Bintray's web interface
-  // The "bintrayName" should match the name of the Bintray repro.
-  bintrayRepo = 'maven'
-  bintrayName = 'om-recorder' // Has to be same as your library module name
-
   // Maven metadata
   publishedGroupId = 'com.kailashdabhi'
   libraryName = 'OmRecorder'
@@ -30,18 +25,14 @@ ext {
   // module. The artifact name needs to match the name of the library.
   artifact = 'om-recorder' // Has to be same as your library module name
 
-  // Your github repo link
+  // Developer's github repo link
   siteUrl = 'https://github.com/kailash09dabhi/OmRecorder'
   gitUrl = 'https://github.com/kailash09dabhi/OmRecorder.git'
 
   libraryDescription =
       'A fluent api wrapper of AudioRecord object to record Pcm & Wav file. There is a listner apis' +
           ' to have audio pulling and also silence detection.'
-  libraryVersion = '1.1.5'
-
-  developerId = 'kailash09dabhi'
-  developerName = 'Kailash Dabhi'
-  developerEmail = 'kailash09dabhi@gmail.com'
+  libraryVersion = '1.1.6-grab'
 
   licenseName = 'The Apache Software License, Version 2.0'
   licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
@@ -56,6 +47,3 @@ tasks.withType(Javadoc) {
   options.addStringOption('Xdoclint:none', '-quiet')
   options.addStringOption('encoding', 'UTF-8')
 }
-
-apply from: 'https://raw.githubusercontent.com/kailash09dabhi/JCenter/master/installv1.gradle'
-apply from: 'https://raw.githubusercontent.com/kailash09dabhi/JCenter/master/bintrayv1.gradle'

--- a/om-recorder/src/main/AndroidManifest.xml
+++ b/om-recorder/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="omrecorder">
+          package="com.omrecorder">
 
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
Merge request to fix [issue 58](https://github.com/kailash09dabhi/OmRecorder/issues/58).

error: attribute 'package' in tag is not a valid Android package name: 'omrecorder'.